### PR TITLE
CLI and assembler fixes

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -218,10 +218,17 @@ impl<'a> TokenizerState<'a> {
                             _               => break
                         }
                     }
+                    let s = &source[start.0 .. state.index];
+                    if s == "-" {
+                        return Err(WsError::new(
+                            ParseError(state.line, state.column, state.index),
+                            "Expected digits"
+                        ))
+                    }
                     TokenType::Integer {
-                        value: if let Ok(value) = source[start.0 .. state.index].parse::<Integer>() {
+                        value: if let Ok(value) = s.parse::<Integer>() {
                             SizedInteger::Small(value)
-                        } else if let Ok(value) = source[start.0 .. state.index].parse::<BigInteger>() {
+                        } else if let Ok(value) = s.parse::<BigInteger>() {
                             SizedInteger::Big(value)
                         } else {
                             unreachable!()

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -159,13 +159,15 @@ impl<'a> TokenizerState<'a> {
         };
         state.next();
         loop {
-            let item;
             // consume whitespace
-            match state.item {
-                Some(' ') | Some('\t') => {state.next(); continue},
-                Some(c)                => item = c,
-                None                   => break
-            }
+            let item = match state.item {
+                Some(c) if c.is_ascii_whitespace() && c != '\n' => {
+                    state.next();
+                    continue;
+                },
+                Some(c) => c,
+                None    => break
+            };
             // match tokens
             // we can distinguish what token to match just on the starting symbol.
             let start = (state.index, state.line, state.column);
@@ -182,10 +184,8 @@ impl<'a> TokenizerState<'a> {
                     // skip ahead to the next non-whitespace so we don't emit a million newline tokens
                     loop {
                         match state.next() {
-                            Some('\n') |
-                            Some(' ')  |
-                            Some('\t') => continue,
-                            _          => break
+                            Some(c) if c.is_ascii_whitespace() => continue,
+                            _                                  => break
                         }
                     }
                     TokenType::Newline

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::error::Error;
 use std::io::{self, Write, Read, BufRead};
 use std::fs::File;
+use std::process;
 use std::time::Instant;
 
 use whitespacers::{Program, Interpreter, Options, debug_compile};
@@ -47,7 +48,10 @@ enum Strategy {
 fn main() {
     match console_main() {
         Ok(()) => (),
-        Err(s) => write!(io::stderr(), "Error: {}\n", s.to_string()).unwrap()
+        Err(s) => {
+            eprintln!("Error: {s}");
+            process::exit(1);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,7 @@ fn parse_args() -> Result<Args, String> {
                 } else {
                     options |= Options::NO_IMPLICIT_EXIT;
                 },
-                "-h" | "--help" => return Err("Usage: whitespacers PROGRAM [-h | -i INFILE | -o OUTFILE | [-t | -e STRATEGY | -d DUMPFILE | -c] | -f FORMAT | -p | --ignore-overflow | --unchecked-heap | --no-fallback]
+                "-h" | "--help" => return Err("Usage: whitespacers PROGRAM [-h | -i INFILE | -o OUTFILE | [-t | -e STRATEGY | -d DUMPFILE | -c] | -f FORMAT | -p | --ignore-overflow | --unchecked-heap | --no-fallback | --no-implicit-exit]
 
 wsc - A really fast whitespace JIT-compiler.
 
@@ -289,7 +289,7 @@ Options:
                              only actually execute a small part of their code.
         async|threaded      Similar to precompiled, but compiles code in a separate thread while
                              already interpreting. It is faster on large programs.
-    -d --count              Use the reference interpreter with no bignum fallback to count the amount
+    -c --count              Use the reference interpreter with no bignum fallback to count the amount
                              of instructions executed.
     -t --translate          Instead of executing, translate the file to/from assembly, and write
                              the result to the specified output.
@@ -310,7 +310,7 @@ Options:
                              this behaviour.
 
 Assembly format:
-    
+
 The assembly format used by wsc is very nasm-like. It supports the following instructions:
 
 Stack manipulation - push INTEGER, dup, swap, copy INTEGER, pop, slide INTEGER

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -318,7 +318,7 @@ fn number_to_ws(mut n: Integer) -> Vec<u8> {
     if n < 0 {
         n = -n;
         res.push(b'\t');
-    } else if n > 0{
+    } else {
         res.push(b' ');
     }
 


### PR DESCRIPTION
This PR makes a few small changes (each commit is atomic):

- Encode 0 with a sign. This is for compatibility with the reference interpreter, which errors when it is missing.
- Exit with status 1 on error.
- Handle all ASCII whitespace so CRLF line endings work.
- Fix `unreachable!` for `-` without digits.
- Fix typos in --help usage.

If you're curious, I've listed Whitespacers in my [Whitespace Corpus](https://github.com/wspace-lang/ws-corpus), which tracks known Whitespace tools.