### PR TITLE
Disassemble assemblable labels and determinize minification

### DIFF
--- a/src/label.rs
+++ b/src/label.rs
@@ -66,16 +66,20 @@ impl Label {
 impl fmt::Display for Label {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let len = self.buffer.len();
-        if self.bits == 0 && len > 0 {
-            if self.buffer[..len - 1].iter().all(|c| match *c {
-                b'a'..=b'z'
-                | b'A'..=b'Z'
-                | b'_' => true,
-                _ => false
-            }) {
-                // as the above characters are all ascii we can safely convert to utf-8
-                return f.write_str(str::from_utf8(&self.buffer[..len - 1]).unwrap());
-            }
+        if self.bits == 0
+            && len > 0
+            && !matches!(self.buffer[0], b'0'..=b'9')
+            && self.buffer[..len - 1].iter().all(|c| {
+                matches!(*c,
+                    b'a'..=b'z'
+                    | b'A'..=b'Z'
+                    | b'0'..=b'9'
+                    | b'_'
+                )
+            })
+        {
+            // as the above characters are all ascii we can safely convert to utf-8
+            return f.write_str(str::from_utf8(&self.buffer[..len - 1]).unwrap());
         }
 
         f.write_char('_')?;

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,5 +1,6 @@
 use num_bigint::BigInt;
 
+use std::cmp::Reverse;
 use std::rc::Rc;
 use std::ops::Range;
 use std::collections::HashMap;
@@ -73,7 +74,7 @@ impl Program {
         };
 
         // create an index => times_used map
-        let mut label_count = HashMap::new();
+        let mut label_count = HashMap::<usize, usize>::new();
         for (i, op) in self.commands.iter().enumerate() {
             match *op {
                 Command::Label => *label_count.entry(i + 1).or_insert(0) += 1,
@@ -85,9 +86,10 @@ impl Program {
             }
         }
 
-        // turn the map into a list of (index, times_used) that is sorted by times_used
+        // turn the map into a list of (index, times_used) that is sorted by times_used,
+        // breaking ties by earlier location
         let mut label_count: Vec<_> = label_count.into_iter().collect();
-        label_count.sort_by_key(|&(_, w)| w);
+        label_count.sort_by_key(|&(index, count)| (Reverse(count), index));
 
         // create an allocator that produces unique labels, starting from the smallest possible label
         let mut length = 0usize;
@@ -95,7 +97,7 @@ impl Program {
         let mut new_label = || {
             // create label
             let mut label = Label::new();
-            for i in 0..length {
+            for i in (0..length).rev() {
                 label.push(value & (1 << i) != 0);
             }
             // increment state
@@ -108,7 +110,7 @@ impl Program {
         };
 
         // from the sorted list, create a map of index => new_label
-        let label_map: HashMap<_, _> = label_count.iter().rev().map(|&(i, _)| (i, new_label())).collect();
+        let label_map: HashMap<_, _> = label_count.iter().map(|&(i, _)| (i, new_label())).collect();
 
         // and edit locs using them.
         for ((i, op), loc) in self.commands.iter().enumerate().zip(locs) {


### PR DESCRIPTION
To complement [f7d1fe1](https://github.com/CensoredUsername/whitespace-rs/commit/f7d1fe1d995358924952ec7e56346f42add4a6e0) (Make binary label format (_010101) translate back from assembly to whitespace, so it round trips better, 2024-12-12), disassemble labels which match the pattern `[a-zA-Z_][a-zA-Z0-9_]*` as ASCII. That is, allow digits after the first character.

Secondly, assign minified labels deterministically. Prefer shorter labels for those more frequently used and break ties by order of label definition. Also, use big-endian order, e.g., 0, 1, 00, 01, 10, 11, 000, 001; instead of 0, 1, 00, 10, 01, 11, 000, 100.